### PR TITLE
Vehicle Rework

### DIFF
--- a/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderBuildable.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderBuildable.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-	<!--===== Leman Russ =====-->
 
 	<Vehicles.VehicleBuildDef ParentName="VehicleBaseBuildable">
 		<defName>GW_LandRaider_Blueprint</defName>
 		<label>Land Raider</label>
-		<description>The Land Raider is a formidable armored transport vehicle, renowned for its versatility and durability on the battlefield. With its rugged design and heavy armor plating, it serves as both a troop transport and a mobile fortress, capable of delivering squads of Space Marines directly into the heart of combat zones while providing fire support with its potent array of weaponry. Its iconic silhouette strikes fear into the hearts of enemies as it advances relentlessly, embodying the indomitable power of the Imperium of Man. \n\n&lt;color=#bb8f04&gt;Crew:&lt;/color&gt; Driver x1, Gunner x2, Passenger x8\n&lt;color=#bb8f04&gt;Fuel type:&lt;/color&gt; Chemfuel</description>
+		<description>The Land Raider is a formidable armored transport vehicle, renowned for its versatility and durability on the battlefield. With its rugged design and heavy armor plating, it serves as both a troop transport and a mobile fortress, capable of delivering squads of Space Marines directly into the heart of combat zones while providing fire support with its potent array of weaponry. Its iconic silhouette strikes fear into the hearts of enemies as it advances relentlessly, embodying the indomitable power of the Imperium of Man. \n\n&lt;color=#bb8f04&gt;Crew:&lt;/color&gt; Driver x1, Gunner x2, Passenger x8\n&lt;color=#bb8f04&gt;Fuel type:&lt;/color&gt; Uranium</description>
 		<designationCategory>GrimworldCategory</designationCategory>
 		<graphicData>
 			<texPath>Things/Vehicles/LandRaider/LandRaider</texPath>
@@ -22,15 +21,15 @@
 			<li>GW_ImperialLandMilitaryEliteVehicleResearch</li>
 		</researchPrerequisites>
 		<costList>
-			<Steel>1200</Steel>
-			<HP_Ceramite>850</HP_Ceramite>
+			<Steel>1000</Steel>
+			<HP_Ceramite>650</HP_Ceramite>
 			<GW_VehicleEngine>1</GW_VehicleEngine>
 			<GW_VehicleExhaust>2</GW_VehicleExhaust>
 			<GW_VehicleSideTurret>3</GW_VehicleSideTurret>
 			<GW_VehicleSuspension>20</GW_VehicleSuspension>
 			<GW_VehicleTracks>2</GW_VehicleTracks>
 			<GW_VehicleWheel>16</GW_VehicleWheel>
-			<ComponentIndustrial>20</ComponentIndustrial>
+			<ComponentIndustrial>10</ComponentIndustrial>
 			<ComponentSpacer>8</ComponentSpacer>
 			<GW_ComponentRelic>2</GW_ComponentRelic>
 		</costList>

--- a/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderPawn.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderPawn.xml
@@ -37,7 +37,6 @@
 			<RepairRate>0.3</RepairRate>
 			<AccelerationRate MayRequire="OskarPotocki.VanillaVehiclesExpanded">0.04</AccelerationRate>
 		</vehicleStats>
-		
 		<soundSustainersOnEvent>
 			<li>
 				<start>IgnitionOn</start>
@@ -45,7 +44,6 @@
 				<value>GW_VoG_HeavySound</value>
 			</li>
 		</soundSustainersOnEvent>
-		
 		<race>
 			<baseBodySize>4.0</baseBodySize>
 		</race>
@@ -367,50 +365,11 @@
 				<fuelConsumptionWorldMultiplier>0.85</fuelConsumptionWorldMultiplier>
 				<fuelCapacity>130</fuelCapacity>
 			</li>
+			<li Class = "Vehicles.CompProperties_UpgradeTree">
+				<def>GW_Landraider_UpgradeTree</def>
+			</li>
 			<li Class="Vehicles.CompProperties_VehicleTurrets">
 				<turrets>
-					<li>
-						<turretDef>GW_LandRaider_twinbolter</turretDef>
-						<renderProperties>
-							<north>(-0.5, 2)</north>
-							<south>(0.7, -2)</south>
-							<east>(2.4, 1)</east>
-							<west>(-2, -0.1)</west>
-						</renderProperties>
-						<gizmoLabel>Frontal Turret</gizmoLabel>
-						<angleRestricted>(-65, 65)</angleRestricted>
-						<aimPieOffset>(0, 0)</aimPieOffset>
-						<drawLayer>1</drawLayer>
-						<key>frontMountedTurret</key>
-					</li>
-					<li>
-						<turretDef>GW_LandRaider_Lasgun</turretDef>
-                        <renderProperties>
-                            <north>(-4.5, -1.2)</north>
-                            <south>(4.5, 1)</south>
-                            <east>(-1, 4)</east>
-                            <west>(1, -3.2)</west>
-                        </renderProperties>
-                        <gizmoLabel>Left Turret</gizmoLabel>
-                        <angleRestricted>(220, 10)</angleRestricted>
-                        <aimPieOffset>(0, 0)</aimPieOffset>
-                        <drawLayer>1</drawLayer>
-                        <key>leftMountedTurret</key>
-                    </li>
-					<li>
-						<turretDef>GW_LandRaider_Lasgun</turretDef>
-						<renderProperties>
-							<north>(4.5, -1.2)</north>
-							<south>(-4.5, 1)</south>
-							<east>(-1, -3.2)</east>
-							<west>(1, 4)</west>
-						</renderProperties>
-						<gizmoLabel>Right Turret</gizmoLabel>
-						<angleRestricted>(-10, 145)</angleRestricted>
-						<aimPieOffset>(0, 0)</aimPieOffset>
-						<drawLayer>1</drawLayer>
-						<key>rightMountedTurret</key>
-					</li>
 				</turrets>
 			</li>
 		</comps>

--- a/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderRedeemer.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderRedeemer.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
+		<defName>GW_RedeemerLandRaiderAC_MainTurret</defName>
+		<label>Land Raider main autocannon</label>
+		<description>WIP</description>
+		<turretType>Rotatable</turretType>
+		<shotSound>Shot_TurretSniper</shotSound>
+		<projectile>GW_SM_Term_VCannonBullet</projectile>
+		<reloadTimer>15.0</reloadTimer>
+		<warmUpTimer>4.0</warmUpTimer>
+		<magazineCapacity>360</magazineCapacity>
+		<chargePerAmmoCount>3</chargePerAmmoCount>
+		<genericAmmo>true</genericAmmo>
+		<hitFlags>IntendedTarget</hitFlags>
+		<autoSnapTargeting>false</autoSnapTargeting>
+		<rotationSpeed>1.5</rotationSpeed>
+		<projectileOffset>4.0</projectileOffset>
+		<projectileShifting>
+			<li>-0.1</li>
+		</projectileShifting>
+		<minRange>5</minRange>
+		<maxRange>50.9</maxRange>
+		<recoil>
+			<distanceTotal>0.25</distanceTotal>
+			<distancePerTick>0.1</distancePerTick>
+			<speedMultiplierPostRecoil>0.25</speedMultiplierPostRecoil>
+		</recoil>
+		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
+		<fireModes>
+			<li>
+				<shotsPerBurst>36</shotsPerBurst>
+				<ticksBetweenShots>2</ticksBetweenShots>
+				<ticksBetweenBursts>120</ticksBetweenBursts>
+				<spreadRadius>4</spreadRadius>
+				<label>Auto</label>
+				<texPath>UI/Gizmos/FireRate_Auto</texPath>
+			</li>
+		</fireModes>
+		<graphicData>
+			<texPath>Things/Vehicles/LandRaider/DualMinigun_Turret</texPath>
+			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
+			<shaderType>CutoutComplexPattern</shaderType>
+			<drawSize>(4.5, 4.5)</drawSize>
+		</graphicData>
+		<ammunition>
+			<thingDefs>
+				<li>GW_HeavyBolterNonCE</li>
+			</thingDefs>
+		</ammunition>
+		<motes>
+			<li>
+				<cycles>1</cycles>
+				<moteDef>Mote_GW_Plume</moteDef>
+				<animationType>Reset</animationType>
+			</li>
+		</motes>
+	</Vehicles.VehicleTurretDef>
+
+	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
+		<defName>GW_LandRaider_Sidebolter</defName>
+		<label>Hurricane Bolter</label>
+		<description>bolt.</description>
+		<turretType>Rotatable</turretType>
+		<shotSound>HP_Heavy_Bolt_Gun_Sound</shotSound>
+		<projectile>HP_Bullet_HeavyBolter</projectile>
+		<reloadTimer>15.8</reloadTimer>
+		<warmUpTimer>3.0</warmUpTimer>
+		<magazineCapacity>600</magazineCapacity>
+		<chargePerAmmoCount>2</chargePerAmmoCount>
+		<genericAmmo>true</genericAmmo>
+		<hitFlags>IntendedTarget</hitFlags>
+		<autoSnapTargeting>false</autoSnapTargeting>
+		<rotationSpeed>2.0</rotationSpeed>
+		<projectileOffset>1.0</projectileOffset>
+		<projectileShifting>
+			<li>-0.2</li>
+			<li>0.2</li>
+		</projectileShifting>
+		<maxRange>28.9</maxRange>
+		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
+		<fireModes>
+			<li>
+				<shotsPerBurst>30</shotsPerBurst>
+				<ticksBetweenShots>4</ticksBetweenShots>
+				<ticksBetweenBursts>60</ticksBetweenBursts>
+				<spreadRadius>3</spreadRadius>
+				<label>Auto</label>
+				<texPath>UI/Gizmos/FireRate_Auto</texPath>
+			</li>
+		</fireModes>
+		<graphicData>
+			<texPath>Things/Vehicles/LandRaider/SideTurret_Bolter</texPath>
+			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
+			<shaderType>CutoutComplexPattern</shaderType>
+			<drawSize>(4.5, 4.5)</drawSize>
+			<layer>1</layer>
+		</graphicData>
+		<ammunition>
+			<thingDefs>
+				<li>GW_HeavyBolterNonCE</li>
+			</thingDefs>
+		</ammunition>
+	</Vehicles.VehicleTurretDef>
+	
+	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
+		<defName>GW_Flamestorm_SideTurret</defName>
+		<label>Flamestorm cannon</label>
+		<description>WIP</description>
+		<turretType>Rotatable</turretType>
+		<shotSound>Shot_MiniFlameblaster</shotSound>
+		<projectile>GW_Bullet_Flamer</projectile>
+		<reloadTimer>8.4</reloadTimer>
+		<warmUpTimer>1.25</warmUpTimer>
+		<magazineCapacity>10</magazineCapacity>
+		<chargePerAmmoCount>10</chargePerAmmoCount>
+		<genericAmmo>true</genericAmmo>
+		<autoSnapTargeting>false</autoSnapTargeting>
+		<rotationSpeed>3.6</rotationSpeed>
+		<projectileOffset>3</projectileOffset>
+		<hitFlags>IntendedTarget</hitFlags>
+		<maxRange>20.9</maxRange>
+		<minRange>1.9</minRange>
+		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
+		<fireModes>
+			<li>
+				<shotsPerBurst>1</shotsPerBurst>
+				<ticksBetweenBursts>1</ticksBetweenBursts>
+				<spreadRadius>3.9</spreadRadius>
+				<label>Fire Spew</label>
+				<texPath>UI/Gizmos/FireRate_Single</texPath>
+			</li>
+		</fireModes>
+		<graphicData>
+			<texPath>Things/Vehicles/LandRaider/SideTurret_Flammer</texPath>
+			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
+			<shaderType>CutoutComplexPattern</shaderType>
+			<drawSize>(4.5, 4.5)</drawSize>
+		</graphicData>
+		<ammunition>
+			<thingDefs>
+				<li>Chemfuel</li>
+			</thingDefs>
+		</ammunition>
+	</Vehicles.VehicleTurretDef>
+	
+	<VFECore.ExpandableProjectileDef ParentName="BaseBullet">
+		<defName>GW_Bullet_Flamer</defName>
+		<label>spew</label>
+		<thingClass>VFECore.FlamethrowProjectile</thingClass>
+		<graphicData>
+			<texPath>Projectiles/FlameSpew</texPath>
+			<texPathFadeOut>Projectiles/FlameExit</texPathFadeOut>
+			<shaderType>MoteGlow</shaderType>
+		</graphicData>
+		<projectile>
+			<damageDef>Flame</damageDef>
+			<speed>45</speed>
+			<damageAmountBase>2</damageAmountBase>
+		</projectile>
+		<drawOffscreen>true</drawOffscreen>
+		<lifeTimeDuration>50</lifeTimeDuration>
+		<widthScaleFactor>0.65</widthScaleFactor>
+		<heightScaleFactor>1</heightScaleFactor>
+		<startingPositionOffset>(0, 0, -1)</startingPositionOffset>
+		<totalSizeScale>1.15</totalSizeScale>
+		<tickFrameRate>2</tickFrameRate>
+		<finalTickFrameRate>5</finalTickFrameRate>
+		<tickDamageRate>20</tickDamageRate>
+		<dealsDamageOnce>true</dealsDamageOnce>
+		<minDistanceToAffect>2</minDistanceToAffect>
+	</VFECore.ExpandableProjectileDef>
+
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderTurrets.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/LandRaider/GW_Tank_LandRaiderTurrets.xml
@@ -5,19 +5,14 @@
 		<defName>GW_LandRaider_Lasgun</defName>
 		<label>lasgun</label>
 		<description>A twinlinked Lascannon, faster than singles, but suffers from worse overheating.</description>
-		
 		<turretType>Rotatable</turretType>
 		<shotSound>OverlordLascannon</shotSound>
-		
 		<projectile>GW_Valkyrielas</projectile>
 		<reloadTimer>3.5</reloadTimer>
 		<warmUpTimer>0.4</warmUpTimer>
-		
 		<magazineCapacity>60</magazineCapacity>
 		<genericAmmo>true</genericAmmo>
-		
 		<hitFlags>IntendedTarget</hitFlags>
-		
 		<autoSnapTargeting>false</autoSnapTargeting>
 		<rotationSpeed>2.95</rotationSpeed>
 			<projectileShifting>
@@ -25,12 +20,8 @@
 			<li>0.2</li>
 		</projectileShifting>
 		<projectileOffset>0</projectileOffset>
-		
 		<minRange>1</minRange>
 		<maxRange>42.9</maxRange>
-		
-		
-		
 		<fireModes>
 			<li>
 				<shotsPerBurst>1</shotsPerBurst>
@@ -41,7 +32,6 @@
 				<texPath>UI/Gizmos/FireRate_Burst</texPath>
 			</li>
 		</fireModes>
-
 		<graphicData>
 			<texPath>Things/Vehicles/LandRaider/SideTurret_Lasgun</texPath>
 			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
@@ -49,16 +39,13 @@
 			<drawSize>(4.5, 4.5)</drawSize>
 			<layer>3</layer>
 		</graphicData>
-		
 		<ammunition>
 			<thingDefs>
 				<li>GW_LascannonammoNonCE</li>
 			</thingDefs>
 		</ammunition>
 	</Vehicles.VehicleTurretDef>
-
-
-
+	
 	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
 		<defName>GW_LandRaider_twinbolter</defName>
 		<label>Twin Heavy Bolter</label>
@@ -83,9 +70,10 @@
 		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
 		<fireModes>
 			<li>
-				<shotsPerBurst>5</shotsPerBurst>
-				<ticksBetweenShots>9</ticksBetweenShots>
-				<ticksBetweenBursts>90</ticksBetweenBursts>
+				<shotsPerBurst>10</shotsPerBurst>
+				<ticksBetweenShots>5</ticksBetweenShots>
+				<ticksBetweenBursts>60</ticksBetweenBursts>
+				<spreadRadius>2</spreadRadius>
 				<label>Auto</label>
 				<texPath>UI/Gizmos/FireRate_Auto</texPath>
 			</li>
@@ -103,12 +91,5 @@
 			</thingDefs>
 		</ammunition>
 	</Vehicles.VehicleTurretDef>
-
-
-
-
-
-
-
 
 </Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/LandRaider/LandRaider_UpgradeTree.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/LandRaider/LandRaider_UpgradeTree.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Defs>
+
+	<Vehicles.UpgradeTreeDef>
+		<defName>GW_Landraider_UpgradeTree</defName>		 
+		<nodes>
+			<li>
+				<key>RedeemerUpgrade</key>
+				<label>Redeemer</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LandRaider/DualMinigun_Turret</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 5)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>CrusaderUpgrade</li>
+				 <li>PhobosUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_RedeemerLandRaiderAC_MainTurret</turretDef>
+								<renderProperties>
+							<north>(-0.5, 2)</north>
+							<south>(0.7, -2)</south>
+							<east>(2.4, 1)</east>
+							<west>(-2, -0.1)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+						        <angleRestricted>(-65, 65)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_LandRaider_Sidebolter</turretDef>
+								<renderProperties>
+                            <north>(-4.5, -1.2)</north>
+                            <south>(4.5, 1)</south>
+                            <east>(-1, 4)</east>
+                            <west>(1, -3.2)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Left Turret</gizmoLabel>
+                                <angleRestricted>(220, 10)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+                              <key>leftMountedTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_LandRaider_Sidebolter</turretDef>
+								<renderProperties>
+							<north>(4.5, -1.2)</north>
+							<south>(-4.5, 1)</south>
+							<east>(-1, -3.2)</east>
+							<west>(1, 4)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Right Turret</gizmoLabel>
+						        <angleRestricted>(-10, 145)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+						        <key>rightMountedTurret</key>
+							</li>
+						</turrets>
+					</li>
+					<li Class = "Vehicles.StatUpgrade">
+						<stats>
+							<li>
+								<def>ArmorRating_Blunt</def>
+								<value>0.05</value>
+							</li>
+							<li>
+								<def>ArmorRating_Sharp</def>
+								<value>0.10</value>
+							</li>
+						</stats>
+						<vehicleStats>
+							<li>
+								<def>Mass</def>
+								<value>50</value>
+							</li>
+						</vehicleStats>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>250</Steel>
+			     <HP_Ceramite>250</HP_Ceramite>
+				 <ComponentIndustrial>10</ComponentIndustrial>
+				 <GW_VehicleCannon>1</GW_VehicleCannon>
+				</ingredients>
+			</li>
+		    <li>
+				<key>CrusaderUpgrade</key>
+				<label>Crusader</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LandRaider/SideTurret_Flammer</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 10)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>RedeemerUpgrade</li>
+				 <li>PhobosUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_RedeemerLandRaiderAC_MainTurret</turretDef>
+								<renderProperties>
+							<north>(-0.5, 2)</north>
+							<south>(0.7, -2)</south>
+							<east>(2.4, 1)</east>
+							<west>(-2, -0.1)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+						        <angleRestricted>(-65, 65)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_Flamestorm_SideTurret</turretDef>
+								<renderProperties>
+                            <north>(-4.5, -1.2)</north>
+                            <south>(4.5, 1)</south>
+                            <east>(-1, 4)</east>
+                            <west>(1, -3.2)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Left Turret</gizmoLabel>
+                                <angleRestricted>(220, 10)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+                              <key>leftMountedTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_Flamestorm_SideTurret</turretDef>
+								<renderProperties>
+							<north>(4.5, -1.2)</north>
+							<south>(-4.5, 1)</south>
+							<east>(-1, -3.2)</east>
+							<west>(1, 4)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Right Turret</gizmoLabel>
+						        <angleRestricted>(-10, 145)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+						        <key>rightMountedTurret</key>
+							</li>
+						</turrets>
+					</li>
+					<li Class = "Vehicles.StatUpgrade">
+						<stats>
+							<li>
+								<def>ArmorRating_Blunt</def>
+								<value>0.05</value>
+							</li>
+							<li>
+								<def>ArmorRating_Sharp</def>
+								<value>0.10</value>
+							</li>
+						</stats>
+						<vehicleStats>
+							<li>
+								<def>Mass</def>
+								<value>50</value>
+							</li>
+						</vehicleStats>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>250</Steel>
+			     <HP_Ceramite>250</HP_Ceramite>
+				 <ComponentIndustrial>10</ComponentIndustrial>
+				 <GW_VehicleCannon>1</GW_VehicleCannon>
+				</ingredients>
+			</li>
+			<li>
+				<key>PhobosUpgrade</key>
+				<label>Phobos</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LandRaider/DualBolter_Turret</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 15)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>RedeemerUpgrade</li>
+				 <li>CrusaderUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_LandRaider_twinbolter</turretDef>
+								<renderProperties>
+							<north>(-0.5, 2)</north>
+							<south>(0.7, -2)</south>
+							<east>(2.4, 1)</east>
+							<west>(-2, -0.1)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+						        <angleRestricted>(-65, 65)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_LandRaider_Lasgun</turretDef>
+								<renderProperties>
+                            <north>(-4.5, -1.2)</north>
+                            <south>(4.5, 1)</south>
+                            <east>(-1, 4)</east>
+                            <west>(1, -3.2)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Left Turret</gizmoLabel>
+                                <angleRestricted>(220, 10)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+                              <key>leftMountedTurret</key>
+							</li>
+							<li>
+								<turretDef>GW_LandRaider_Lasgun</turretDef>
+								<renderProperties>
+							<north>(4.5, -1.2)</north>
+							<south>(-4.5, 1)</south>
+							<east>(-1, -3.2)</east>
+							<west>(1, 4)</west>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Right Turret</gizmoLabel>
+						        <angleRestricted>(-10, 145)</angleRestricted>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+						        <key>rightMountedTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>250</Steel>
+			     <HP_Ceramite>250</HP_Ceramite>
+				 <ComponentIndustrial>10</ComponentIndustrial>
+				 <GW_VehicleCannon>1</GW_VehicleCannon>
+				</ingredients>
+			</li>
+		</nodes>
+	</Vehicles.UpgradeTreeDef>
+	
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanBuildable.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanBuildable.xml
@@ -22,9 +22,8 @@
 			<li>GW_ImperialLandMilitaryHeavyVehicleResearch</li>
 		</researchPrerequisites>
 		<costList>
-			<Steel>500</Steel>
-			<HP_Ceramite>450</HP_Ceramite>
-			<GW_VehicleCannon>1</GW_VehicleCannon>
+			<Steel>400</Steel>
+			<HP_Ceramite>350</HP_Ceramite>
 			<GW_VehicleEngine>1</GW_VehicleEngine>
 			<GW_VehicleExhaust>2</GW_VehicleExhaust>
 			<GW_VehicleSideTurret>3</GW_VehicleSideTurret>

--- a/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanPawn.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanPawn.xml
@@ -37,7 +37,6 @@
 			<RepairRate>0.3</RepairRate>
 			<AccelerationRate MayRequire="OskarPotocki.VanillaVehiclesExpanded">0.04</AccelerationRate>
 		</vehicleStats>
-		
 		<soundSustainersOnEvent>
 			<li>
 				<start>IgnitionOn</start>
@@ -45,7 +44,6 @@
 				<value>GW_VoG_HeavySound</value>
 			</li>
 		</soundSustainersOnEvent>
-		
 		<race>
 			<baseBodySize>4.0</baseBodySize>
 		</race>
@@ -356,21 +354,11 @@
 				<fuelConsumptionWorldMultiplier>0.85</fuelConsumptionWorldMultiplier>
 				<fuelCapacity>130</fuelCapacity>
 			</li>
+		    <li Class = "Vehicles.CompProperties_UpgradeTree">
+				<def>GW_Lemanruss_UpgradeTree</def>
+			</li>
 			<li Class="Vehicles.CompProperties_VehicleTurrets">
 				<turrets>
-					<li>
-						<turretDef>GW_LemanRuss_MainTurret</turretDef>
-						<renderProperties>
-							<north>(0, 0.1)</north>
-							<south>(0, -0.1)</south>
-							<east>(0.1, 0.1)</east>
-						</renderProperties>
-						<gizmoLabel>Main Turret</gizmoLabel>
-						<angleRestricted />
-						<aimPieOffset>(0, 1.75)</aimPieOffset>
-						<drawLayer>2</drawLayer>
-						<key>mainTurret</key>
-					</li>
 					<li>
 						<turretDef>GW_LemanRuss_HeavyBolter</turretDef>
 						<renderProperties>

--- a/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanPunisherTurret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanPunisherTurret.xml
@@ -25,7 +25,7 @@
 	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
 		<defName>GW_LemanRussPunisher_MainTurret</defName>
 		<label>Leman Russ main cannon</label>
-		<description>A turret-mounted Punisher Gatling Cannon, a rapid-fire rotary cannon used as the main weapon of the Leman Russ Punisher. Fires 0.787 cal autocannon rounds.</description>
+		<description>The Lemann Russ Main Battle Cannon, a formidable weapon in the war-torn landscape of GrimWorld 40,000, is mounted on a heavily armored vehicle. The cannon boasts a rugged design with reinforced plating, reflecting the harsh aesthetic of the 41st millennium.\n\nPositioned on the vehicle's chassis, the cannon is a symbol of raw, devastating firepower. Its sleek barrel and menacing presence underscore its role as a primary anti-armor and anti-infantry weapon. Adorned with Imperial symbols, it signifies the might of the Imperium in the relentless battle against myriad threats.</description>
 		<turretType>Rotatable</turretType>
 		<shotSound>Shot_TurretSniper</shotSound>
 		<projectile>Bullet_LemanRussPunisher_MainTurret</projectile>
@@ -55,7 +55,7 @@
 				<ticksBetweenShots>2</ticksBetweenShots>
 				<ticksBetweenBursts>5</ticksBetweenBursts>
 				<label>Single</label>
-				<spreadRadius>7</spreadRadius>
+				<spreadRadius>6</spreadRadius>
 				<texPath>UI/Gizmos/FireRate_Single</texPath>
 			</li>
 		</fireModes>

--- a/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanTurret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Leman Russ/GW_Tank_LemanTurret.xml
@@ -12,7 +12,7 @@
 		</graphicData>
 		<projectile>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>150</damageAmountBase>
+			<damageAmountBase>80</damageAmountBase>
 			<speed>90</speed>
 			<explosionRadius>5.9</explosionRadius>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>

--- a/1.5/Defs/ThingDefs_Vehicles/Leman Russ/LemanRuss_UpgradeTree.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Leman Russ/LemanRuss_UpgradeTree.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Defs>
+
+	<Vehicles.UpgradeTreeDef>
+		<defName>GW_Lemanruss_UpgradeTree</defName>		 
+		<nodes>
+			<li>
+				<key>ExecutionerUpgrade</key>
+				<label>Executioner</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LemanRuss/LemanRussExecutioner_Cannon</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 5)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>PunisherUpgrade</li>
+				 <li>BasicLemanUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_LemanRussExecutioner_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, -0.1)</south>
+							<east>(0.1, 0.1)</east>
+								</renderProperties>
+								<drawLayer>2</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+		    <li>
+				<key>PunisherUpgrade</key>
+				<label>Punisher</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LemanRuss/LemanRussExecutioner_Cannon</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 10)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>ExecutionerUpgrade</li>
+				 <li>BasicLemanUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_LemanRussPunisher_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, -0.1)</south>
+							<east>(0.1, 0.1)</east>
+								</renderProperties>
+								<drawLayer>2</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+			<li>
+				<key>BasicLemanUpgrade</key>
+				<label>Standard</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/LemanRuss/LemanRuss_CannonTop</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 15)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>ExecutionerUpgrade</li>
+				 <li>PunisherUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_LemanRuss_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, -0.1)</south>
+							<east>(0.1, 0.1)</east>
+								</renderProperties>
+								<drawLayer>2</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+		</nodes>
+	</Vehicles.UpgradeTreeDef>
+	
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_BaalPredatorTurret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_BaalPredatorTurret.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
+		<defName>GW_BaalPredator_MainTurret</defName>
+		<label>Predator main autocannon</label>
+		<description>WIP</description>
+		<turretType>Rotatable</turretType>
+		<shotSound>Shot_TurretSniper</shotSound>
+		<projectile>GW_SM_Term_VCannonBullet</projectile>
+		<reloadTimer>15.0</reloadTimer>
+		<warmUpTimer>4.0</warmUpTimer>
+		<magazineCapacity>360</magazineCapacity>
+		<chargePerAmmoCount>3</chargePerAmmoCount>
+		<genericAmmo>true</genericAmmo>
+		<hitFlags>IntendedTarget</hitFlags>
+		<autoSnapTargeting>false</autoSnapTargeting>
+		<rotationSpeed>1.5</rotationSpeed>
+		<projectileOffset>4.0</projectileOffset>
+		<projectileShifting>
+			<li>-0.1</li>
+		</projectileShifting>
+		<minRange>5</minRange>
+		<maxRange>50.9</maxRange>
+		<recoil>
+			<distanceTotal>0.25</distanceTotal>
+			<distancePerTick>0.1</distancePerTick>
+			<speedMultiplierPostRecoil>0.25</speedMultiplierPostRecoil>
+		</recoil>
+		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
+		<fireModes>
+			<li>
+				<shotsPerBurst>36</shotsPerBurst>
+				<ticksBetweenShots>2</ticksBetweenShots>
+				<ticksBetweenBursts>120</ticksBetweenBursts>
+				<label>Auto</label>
+				<texPath>UI/Gizmos/FireRate_Auto</texPath>
+			</li>
+		</fireModes>
+		<graphicData>
+			<texPath>Things/Vehicles/Predator/Predator_Cannontop_Gatling</texPath>
+			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
+			<shaderType>CutoutComplexPattern</shaderType>
+			<drawSize>(7, 7)</drawSize>
+		</graphicData>
+		<ammunition>
+			<thingDefs>
+				<li>GW_HeavyBolterNonCE</li>
+			</thingDefs>
+		</ammunition>
+		<motes>
+			<li>
+				<cycles>1</cycles>
+				<moteDef>Mote_GW_Plume</moteDef>
+				<animationType>Reset</animationType>
+			</li>
+		</motes>
+	</Vehicles.VehicleTurretDef>
+	
+	<ThingDef ParentName="BaseBullet">
+		<defName>GW_SM_Term_VCannonBullet</defName>
+		<label>cannon shot</label>
+		<graphicData>
+			<texPath>Things/Projectiles/Bolter_Projectile</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>1.7</drawSize>
+		</graphicData>
+		<projectile>
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>30</damageAmountBase>
+			<stoppingPower>0.8</stoppingPower>
+			<armorPenetrationBase>0.30</armorPenetrationBase>
+			<speed>80</speed>
+		</projectile>
+	</ThingDef>
+
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorAnihilator_Turret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorAnihilator_Turret.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+
+   <ThingDef ParentName="GW_LaserBullet" Class="VanillaWeaponsExpandedLaser.LaserBeamDef">
+        <defName>GW_Predatorlas</defName>
+        <label>Lascanon shot</label>
+        <description>WIP</description>
+        <textures>
+            <li>Things/Projectiles/Las_Bolt</li>
+        </textures>
+        <seam>0</seam>
+        <causefireChance>0.08</causefireChance>
+        <projectile>
+            <damageDef>Burn</damageDef>
+            <damageAmountBase>100</damageAmountBase>
+            <armorPenetrationBase>1</armorPenetrationBase>
+            <stoppingPower>2.0</stoppingPower>
+        </projectile>
+    </ThingDef>
+
+	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
+		<defName>GW_PredatorAnihilator_MainTurret</defName>
+		<label>Predator main cannon</label>
+		<description>WIP</description>
+		<turretType>Rotatable</turretType>
+		<shotSound>OverlordLascannon</shotSound>
+		<projectile>GW_Predatorlas</projectile>
+		<reloadTimer>12.0</reloadTimer>
+		<warmUpTimer>4.0</warmUpTimer>
+		<magazineCapacity>6</magazineCapacity>
+		<chargePerAmmoCount>1</chargePerAmmoCount>
+		<genericAmmo>true</genericAmmo>
+		<hitFlags>IntendedTarget</hitFlags>
+		<autoSnapTargeting>false</autoSnapTargeting>
+		<rotationSpeed>1.0</rotationSpeed>
+		<projectileOffset>4.0</projectileOffset>
+		<projectileShifting>
+			<li>-0.1</li>
+		</projectileShifting>
+		<minRange>5</minRange>
+		<maxRange>60.9</maxRange>
+		<recoil>
+			<distanceTotal>0.25</distanceTotal>
+			<distancePerTick>0.1</distancePerTick>
+			<speedMultiplierPostRecoil>0.25</speedMultiplierPostRecoil>
+		</recoil>
+		<attachProjectileFlag>GW_Tank</attachProjectileFlag>
+		<fireModes>
+			<li>
+				<shotsPerBurst>1</shotsPerBurst>
+				<ticksBetweenShots>22</ticksBetweenShots>
+				<ticksBetweenBursts>70</ticksBetweenBursts>
+				<label>Single</label>
+				<texPath>UI/Gizmos/FireRate_Single</texPath>
+			</li>
+		</fireModes>
+		<graphicData>
+			<texPath>Things/Vehicles/Predator/Predator_LasCannonTop</texPath>
+			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
+			<shaderType>CutoutComplexPattern</shaderType>
+			<drawSize>(6, 6)</drawSize>
+		</graphicData>
+		<ammunition>
+			<thingDefs>
+				<li>GW_LascannonammoNonCE</li>
+			</thingDefs>
+		</ammunition>
+		<motes>
+			<li>
+				<cycles>1</cycles>
+				<moteDef>Mote_GW_Plume</moteDef>
+				<animationType>Reset</animationType>
+			</li>
+		</motes>
+	</Vehicles.VehicleTurretDef>
+	
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorBuildable.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorBuildable.xml
@@ -22,17 +22,16 @@
 			<li>GW_ImperialLandMilitaryHeavyVehicleResearch</li>
 		</researchPrerequisites>
 		<costList>
-			<Steel>650</Steel>
-			<HP_Ceramite>300</HP_Ceramite>
-			<HP_Adamantium>15</HP_Adamantium>
-			<GW_VehicleCannon>1</GW_VehicleCannon>
+			<Steel>550</Steel>
+			<HP_Ceramite>200</HP_Ceramite>
+			<HP_Adamantium>10</HP_Adamantium>
 			<GW_VehicleEngine>1</GW_VehicleEngine>
 			<GW_VehicleExhaust>2</GW_VehicleExhaust>
 			<GW_VehicleSideTurret>2</GW_VehicleSideTurret>
 			<GW_VehicleSuspension>14</GW_VehicleSuspension>
 			<GW_VehicleTracks>2</GW_VehicleTracks>
 			<GW_VehicleWheel>22</GW_VehicleWheel>
-			<ComponentIndustrial>20</ComponentIndustrial>
+			<ComponentIndustrial>16</ComponentIndustrial>
 		</costList>
 		<soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
 		<thingToSpawn>GW_Predator</thingToSpawn>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorExecutioner_Turret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorExecutioner_Turret.xml
@@ -2,7 +2,7 @@
 <Defs>
 
 	<ThingDef ParentName="BaseBullet">
-		<defName>Bullet_LemanRussExecutioner_MainTurret</defName>
+		<defName>Bullet_PredatorExecutioner_MainTurret</defName>
 		<label>high-explosive shell</label>
 		<thingClass>Projectile_Explosive</thingClass>
 		<graphicData>
@@ -25,12 +25,12 @@
 	</ThingDef>
 
 	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
-		<defName>GW_LemanRussExecutioner_MainTurret</defName>
-		<label>Leman Russ main cannon</label>
-		<description>The Lemann Russ Main Battle Cannon, a formidable weapon in the war-torn landscape of GrimWorld 40,000, is mounted on a heavily armored vehicle. The cannon boasts a rugged design with reinforced plating, reflecting the harsh aesthetic of the 41st millennium.\n\nPositioned on the vehicle's chassis, the cannon is a symbol of raw, devastating firepower. Its sleek barrel and menacing presence underscore its role as a primary anti-armor and anti-infantry weapon. Adorned with Imperial symbols, it signifies the might of the Imperium in the relentless battle against myriad threats.</description>
+		<defName>GW_PredatorExecutioner_MainTurret</defName>
+		<label>Predator main cannon</label>
+		<description>WIP</description>
 		<turretType>Rotatable</turretType>
 		<shotSound>Shot_TurretSniper</shotSound>
-		<projectile>Bullet_LemanRussExecutioner_MainTurret</projectile>
+		<projectile>Bullet_PredatorExecutioner_MainTurret</projectile>
 		<reloadTimer>12.0</reloadTimer>
 		<warmUpTimer>4.0</warmUpTimer>
 		<magazineCapacity>6</magazineCapacity>
@@ -61,7 +61,7 @@
 			</li>
 		</fireModes>
 		<graphicData>
-			<texPath>Things/Vehicles/LemanRuss/LemanRussExecutioner_Cannon</texPath>
+			<texPath>Things/Vehicles/Predator/Predator_Cannontop_Plasma</texPath>
 			<graphicClass>Vehicles.Graphic_Turret</graphicClass>
 			<shaderType>CutoutComplexPattern</shaderType>
 			<drawSize>(6, 6)</drawSize>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorPawn.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorPawn.xml
@@ -37,7 +37,6 @@
 			<RepairRate>0.3</RepairRate>
 			<AccelerationRate MayRequire="OskarPotocki.VanillaVehiclesExpanded">0.09</AccelerationRate>
 		</vehicleStats>
-		
 		<soundSustainersOnEvent>
 			<li>
 				<start>IgnitionOn</start>
@@ -45,7 +44,6 @@
 				<value>GW_VoG_HeavySound</value>
 			</li>
 		</soundSustainersOnEvent>
-		
 		<race>
 			<baseBodySize>4.0</baseBodySize>
 		</race>
@@ -345,21 +343,11 @@
 				<fuelConsumptionWorldMultiplier>0.75</fuelConsumptionWorldMultiplier>
 				<fuelCapacity>115</fuelCapacity>
 			</li>
+			<li Class = "Vehicles.CompProperties_UpgradeTree">
+				<def>GW_Predator_UpgradeTree</def>
+			</li>
 			<li Class="Vehicles.CompProperties_VehicleTurrets">
 				<turrets>
-					<li>
-						<turretDef>GW_Predator_MainTurret</turretDef>
-						<renderProperties>
-							<north>(0, 0.1)</north>
-							<south>(0, 0.2)</south>
-							<east>(0, 0.5)</east>
-						</renderProperties>
-						<gizmoLabel>Main Turret</gizmoLabel>
-						<angleRestricted />
-						<aimPieOffset>(0, 2.0)</aimPieOffset>
-						<drawLayer>1</drawLayer>
-						<key>mainTurret</key>
-					</li>
 					<li>
 						<turretDef>GW_Predator_HeavyBolter</turretDef>
 						<renderProperties>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorTurret.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/GW_Tank_PredatorTurret.xml
@@ -25,7 +25,7 @@
 	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
 		<defName>GW_Predator_MainTurret</defName>
 		<label>Predator main autocannon</label>
-		<description>A turret-mounted Syrtis-pattern autocannon, used as the main weapon on Predator battle tanks. Fires 0.787 cal autocannon rounds.</description>
+		<description>The Autocannon, a potent ballistic weapon in GrimWorld 40,000, is mounted on a robust vehicle. With a sleek design and formidable presence, this versatile armament embodies precision and rapid-fire capability. Integrated into battle-tested plating, the vehicle signifies the Imperium's relentless might in confronting armored and infantry threats on the tumultuous battlefield.</description>
 		<turretType>Rotatable</turretType>
 		<shotSound>Shot_TurretSniper</shotSound>
 		<projectile>Bullet_Predator_MainTurret</projectile>
@@ -96,7 +96,7 @@
 	<Vehicles.VehicleTurretDef ParentName="VehicleTurretBase">
 		<defName>GW_Predator_HeavyBolter</defName>
 		<label>Predator Heavy Bolter</label>
-		<description>A sponson-mounted heavy bolter used on the Predator. Fires 0.998 cal bolts.</description>
+		<description>The Heavy Bolter, a formidable weapon in the Warhammer 40,000 universe, is often mounted on vehicles to enhance their firepower. This versatile weapon, characterized by its rapid and powerful firepower, serves as a potent anti-infantry and suppressive tool on the battlefield. When mounted on a vehicle, it becomes a symbol of mobile and devastating firepower, capable of mowing down enemy infantry and providing valuable support in diverse combat scenarios.</description>
 		<turretType>Rotatable</turretType>
 		<shotSound>HP_Heavy_Bolt_Gun_Sound</shotSound>
 		<projectile>HP_Bullet_HeavyBolter</projectile>

--- a/1.5/Defs/ThingDefs_Vehicles/Predator/Predator_UpgradeTree.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Predator/Predator_UpgradeTree.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Defs>
+
+	<Vehicles.UpgradeTreeDef>
+		<defName>GW_Predator_UpgradeTree</defName>
+		<nodes>
+			<li>
+				<key>ExecutionerPUpgrade</key>
+				<label>Executioner</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/Predator/Predator_Cannontop_Plasma</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 5)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>AnnihilatorUpgrade</li>
+				 <li>BaalUpgrade</li>
+				 <li>DestructorUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_PredatorExecutioner_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, 0.2)</south>
+							<east>(0, 0.5)</east>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <HP_Adamantium>5</HP_Adamantium>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+		    <li>
+				<key>BaalUpgrade</key>
+				<label>Baal</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/Predator/Predator_Cannontop_Gatling</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 10)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>AnnihilatorUpgrade</li>
+				 <li>ExecutionerPUpgrade</li>
+				 <li>DestructorUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_BaalPredator_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, 0.2)</south>
+							<east>(0, 0.5)</east>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <HP_Adamantium>5</HP_Adamantium>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+			<li>
+				<key>DestructorUpgrade</key>
+				<label>Destructor</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/Predator/Predator_CannonTop</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 15)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>AnnihilatorUpgrade</li>
+				 <li>ExecutionerPUpgrade</li>
+				 <li>BaalUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_Predator_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, 0.2)</south>
+							<east>(0, 0.5)</east>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <HP_Adamantium>5</HP_Adamantium>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+			<li>
+				<key>AnihilatorUpgrade</key>
+				<label>Anihilator</label>
+				<description>WIP</description>
+				<icon>Things/Vehicles/Predator/Predator_CannonTop</icon>
+				<work>7500</work>
+				<gridCoordinate>(5, 20)</gridCoordinate>
+				<drawSize>(80, 80)</drawSize>
+				<disableIfUpgradeNodesEnabled>
+				 <li>DestructorUpgrade</li>
+				 <li>ExecutionerPUpgrade</li>
+				 <li>BaalUpgrade</li>
+				</disableIfUpgradeNodesEnabled>
+				<upgrades>
+					<li Class = "Vehicles.TurretUpgrade">
+						<turrets>
+							<li>
+								<turretDef>GW_PredatorAnihilator_MainTurret</turretDef>
+								<renderProperties>
+							<north>(0, 0.1)</north>
+							<south>(0, 0.2)</south>
+							<east>(0, 0.5)</east>
+								</renderProperties>
+								<drawLayer>1</drawLayer>
+								<gizmoLabel>Main Turret</gizmoLabel>
+								<angleRestricted/>
+								<aimPieOffset>(0, 1.4)</aimPieOffset>
+								<key>mainTurret</key>
+							</li>
+						</turrets>
+					</li>
+				</upgrades>
+				<ingredients>
+				 <Steel>100</Steel>
+			     <GW_VehicleCannon>1</GW_VehicleCannon>
+			     <HP_Ceramite>100</HP_Ceramite>
+				 <HP_Adamantium>5</HP_Adamantium>
+				 <ComponentIndustrial>4</ComponentIndustrial>
+				</ingredients>
+			</li>
+		</nodes>
+	</Vehicles.UpgradeTreeDef>
+	
+</Defs>

--- a/1.5/Defs/ThingDefs_Vehicles/Valkyrie/GW_Tank_Valkyrieweapons.xml
+++ b/1.5/Defs/ThingDefs_Vehicles/Valkyrie/GW_Tank_Valkyrieweapons.xml
@@ -36,7 +36,7 @@
         <causefireChance>0.08</causefireChance>
         <projectile>
             <damageDef>Burn</damageDef>
-            <damageAmountBase>170</damageAmountBase>
+            <damageAmountBase>100</damageAmountBase>
             <armorPenetrationBase>1</armorPenetrationBase>
             <stoppingPower>2.0</stoppingPower>
         </projectile>
@@ -74,7 +74,7 @@
 		
 		<fireModes>
 			<li>
-				<shotsPerBurst>5</shotsPerBurst>
+				<shotsPerBurst>1</shotsPerBurst>
 				<ticksBetweenShots>5</ticksBetweenShots>
 				<ticksBetweenBursts>30</ticksBetweenBursts>
 				<label>Single</label>


### PR DESCRIPTION
ALL VEHICLES NOW COST LESS MATERIALS TO MAKE, this cost is then put onto the cost of "upgrading" them to have a turret, as they now start naked if a cost comes with a slight extra, it means it comes with another small upgrade (land raider redeemers-crusaders get a slight armor buff)

- punisher cannon no longer has explosive rounds, spread decreased by 1 to help hit targets better however
- added spread to some bolter weapons on vehicles
- leman russ cannon reduced to 90, its using HE shells, not AP rounds people
- lascannons reduced to 100 damage
- valkryie no longer burst fires lascannon as if its a multilaser
- added a vehicle cannon to the cost of the lander raider overall